### PR TITLE
Remove usage of 'canary'

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -1,7 +1,7 @@
 version: 1.0.0
 variables:
   global:
-    HOSTING_API_STAGE: canary
+    HOSTING_API_STAGE: prod
 events:
   build:
     steps:


### PR DESCRIPTION
As part of https://backlog.acquia.com/browse/PUB-19418 make sure we don't leak out the existence of the 'canary' realm.